### PR TITLE
Fixed profiler crashes when enabled on `User::getUsername()`

### DIFF
--- a/src/contracts/WebTestCase.php
+++ b/src/contracts/WebTestCase.php
@@ -70,6 +70,7 @@ abstract class WebTestCase extends SymfonyWebTestCase
         $apiUser = $userService->loadUserByLogin('admin');
         $symfonyUser = $this->createMock(UserInterface::class);
         $symfonyUser->method('getRoles')->willReturn(['ROLE_USER']);
+        $symfonyUser->method('getUsername')->willReturn('admin');
 
         return new UserWrapped($symfonyUser, $apiUser);
     }


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | N/A
| **Type**                       | bug
| **Target eZ Platform version** | N/A
| **BC breaks**                  | no                                                |
| **Doc needed**                 | no                                                |

Fixes an issue that occurs when Symfony Profiler is enabled for request (needed by, for example, `TraceableHttpClient` wrapping and subsequent request/response checks).
```yaml
framework:
    profiler: true
```
Stacktrace:
```
TypeError : Return value of Symfony\Component\Security\Core\Authentication\Token\AbstractToken::getUserIdentifier() must be of the type string, null returned
 /.../vendor/symfony/security-core/Authentication/Token/AbstractToken.php:82
 /.../vendor/symfony/security-bundle/DataCollector/SecurityDataCollector.php:138
 /.../vendor/symfony/http-kernel/Profiler/Profiler.php:161
 /.../vendor/symfony/http-kernel/EventListener/ProfilerListener.php:108
 /.../vendor/symfony/event-dispatcher/Debug/WrappedListener.php:118
 /.../vendor/symfony/event-dispatcher/EventDispatcher.php:230
 /.../vendor/symfony/event-dispatcher/EventDispatcher.php:59
 /.../vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:154
 /.../vendor/symfony/http-kernel/HttpKernel.php:196
 /.../vendor/symfony/http-kernel/HttpKernel.php:184
 /.../vendor/symfony/http-kernel/HttpKernel.php:75
 /.../vendor/symfony/http-kernel/Kernel.php:202
 /.../vendor/symfony/http-kernel/HttpKernelBrowser.php:65
 /.../vendor/symfony/framework-bundle/KernelBrowser.php:183
 /.../vendor/symfony/browser-kit/AbstractBrowser.php:398
 /.../tests/integration/REST/...Test.php:19
 ```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
