### PR TITLE
Fixed justinrainbow/json-schema not being required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "ibexa/test-core": "~0.1.x-dev",
+    "justinrainbow/json-schema": "^5.2",
     "symfony/browser-kit": "^5.4",
     "symfony/mime": "^5.4",
     "symfony/proxy-manager-bridge": "^5.4",
@@ -20,7 +21,6 @@
   "require-dev": {
     "ibexa/code-style": "^1.1",
     "ibexa/core": "~4.4.x-dev",
-    "justinrainbow/json-schema": "^5.2",
     "phpstan/phpstan": "^1.2",
     "phpstan/phpstan-phpunit": "^1.0",
     "phpunit/phpunit": "^9"


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | N/A
| **Type**                       | improvement
| **Target eZ Platform version** | `v0.1`
| **BC breaks**                  | no                                                |
| **Doc needed**                 | no                                                |

Moves `justinrainbow/json-schema` into `required` section in composer.json, so that dependent packages do not need to explicitly have it as dependency.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
