### PR TITLE
Improved debugging of failed schema validation

### DIFF
--- a/src/contracts/BaseRestWebTestCase.php
+++ b/src/contracts/BaseRestWebTestCase.php
@@ -165,8 +165,22 @@ abstract class BaseRestWebTestCase extends WebTestCase
         string $resourceType,
         string $format
     ): void {
-        $validator = $this->getSchemaValidator($format);
-        $validator->validate($response, $this->getSchemaFileBasePath($resourceType, $format));
+        try {
+            $validator = $this->getSchemaValidator($format);
+            $validator->validate($response, $this->getSchemaFileBasePath($resourceType, $format));
+        } catch (\Throwable $e) {
+            self::fail(
+                sprintf(
+                    'Failed to validate against schema the response of Media Type %s in %s format. ' .
+                    "The response was:\n%s\n" .
+                    "The exception was:\n%s\n",
+                    $resourceType,
+                    $format,
+                    $response,
+                    $e
+                )
+            );
+        }
     }
 
     private function getSchemaValidator(string $format): ValidatorInterface


### PR DESCRIPTION
This PR improves debugging of failed validation against XSD and JSON schemas. If validation fails it's good to actually see the response it failed against. Before the change the feedback from validation tools was too vague and it required to either dump or do debugging session to see the actual response contents.

After the change, the sample failure is shown directly as PHPUnit failure, for example:
```
Failed to validate against schema the response of Media Type ShipmentRefList in xml format. The response was:
<?xml version="1.0" encoding="UTF-8"?>
<ShipmentRefList media-type="application/vnd.ibexa.api.ShipmentRefList+xml" href="/api/ibexa/v2/shipments">
 <ShipmentRef media-type="application/vnd.ibexa.api.Shipment+xml" href="/api/ibexa/v2/order/4ac4b8a0-eed8-496d-87d9-32a960a10629/shipments/foo"/>
 <ShipmentRef media-type="application/vnd.ibexa.api.Shipment+xml" href="/api/ibexa/v2/order/37ca103f-66e6-4dea-8251-06a290d1199c/shipments/bar"/>
 <ShipmentRef media-type="application/vnd.ibexa.api.Shipment+xml" href="/api/ibexa/v2/order/f7578972-e7f4-4cae-85dc-a7c74610204e/shipments/baz"/>
 <ShipmentRef media-type="application/vnd.ibexa.api.Shipment+xml" href="/api/ibexa/v2/order/9f02709a-5c70-4e1f-9f04-6fbc7e7674b5/shipments/qux"/>
</ShipmentRefList>

The exception was:
DOMDocument::schemaValidate(): Element 'ShipmentRef': This element is not expected.

/home/andrew/packages/ibexa/shipping/vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php:132
/home/andrew/packages/ibexa/test-rest/src/lib/Schema/Validator/XmlSchemaValidator.php:17
/home/andrew/packages/ibexa/test-rest/src/contracts/BaseRestWebTestCase.php:170
/home/andrew/packages/ibexa/test-rest/src/contracts/BaseRestWebTestCase.php:122
/home/andrew/packages/ibexa/test-rest/src/contracts/BaseRestWebTestCase.php:50


 /home/andrew/packages/ibexa/test-rest/src/contracts/BaseRestWebTestCase.php:174
 /home/andrew/packages/ibexa/test-rest/src/contracts/BaseRestWebTestCase.php:122
 /home/andrew/packages/ibexa/test-rest/src/contracts/BaseRestWebTestCase.php:50
```
