### PR TITLE
Allowed payload to be replaced in EndpointRequestDefinition

### DIFF
--- a/src/contracts/Input/PayloadLoader.php
+++ b/src/contracts/Input/PayloadLoader.php
@@ -29,6 +29,6 @@ final class PayloadLoader implements PayloadLoaderInterface
         $content = file_get_contents($filePath);
         Assert::assertNotFalse($content, "Failed to load file '$filePath' contents");
 
-        return new InputPayload($mediaType, $format, $content);
+        return new InputPayload($mediaType, $format, $content, "$payloadName $format");
     }
 }

--- a/src/contracts/Input/Value/InputPayload.php
+++ b/src/contracts/Input/Value/InputPayload.php
@@ -18,7 +18,7 @@ final class InputPayload implements \Stringable
 
     private ?string $name;
 
-    public function __construct(string $mediaType, string $format, string $content, ?string $name = null)
+    public function __construct(string $mediaType, string $format, string $content, string $name)
     {
         $this->mediaType = $mediaType;
         $this->format = $format;
@@ -43,6 +43,6 @@ final class InputPayload implements \Stringable
 
     public function __toString(): string
     {
-        return $this->name ?? "$this->mediaType $this->format";
+        return $this->name;
     }
 }

--- a/src/contracts/Input/Value/InputPayload.php
+++ b/src/contracts/Input/Value/InputPayload.php
@@ -16,7 +16,7 @@ final class InputPayload implements \Stringable
 
     private string $content;
 
-    private ?string $name;
+    private string $name;
 
     public function __construct(string $mediaType, string $format, string $content, string $name)
     {

--- a/src/contracts/Input/Value/InputPayload.php
+++ b/src/contracts/Input/Value/InputPayload.php
@@ -16,9 +16,9 @@ final class InputPayload implements \Stringable
 
     private string $content;
 
-    private string $name;
+    private ?string $name;
 
-    public function __construct(string $mediaType, string $format, string $content, string $name)
+    public function __construct(string $mediaType, string $format, string $content, ?string $name = null)
     {
         $this->mediaType = $mediaType;
         $this->format = $format;
@@ -43,6 +43,6 @@ final class InputPayload implements \Stringable
 
     public function __toString(): string
     {
-        return $this->name;
+        return $this->name ?? "$this->mediaType $this->format";
     }
 }

--- a/src/contracts/Request/Value/EndpointRequestDefinition.php
+++ b/src/contracts/Request/Value/EndpointRequestDefinition.php
@@ -46,7 +46,7 @@ final class EndpointRequestDefinition implements Stringable
         string $method,
         string $uri,
         ?string $expectedResourceType,
-        ?string $acceptHeader,
+        ?string $acceptHeader = null,
         array $headers = [],
         ?InputPayload $payload = null,
         ?string $name = null,
@@ -153,6 +153,14 @@ final class EndpointRequestDefinition implements Stringable
     {
         $endpointDefinition = clone $this;
         $endpointDefinition->acceptHeader = $acceptHeader;
+
+        return $endpointDefinition;
+    }
+
+    public function withPayload(?InputPayload $payload): self
+    {
+        $endpointDefinition = clone $this;
+        $endpointDefinition->payload = $payload;
 
         return $endpointDefinition;
     }


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | N/A |
| **Type**                       | feature/bug/improvement                               |
| **Target eZ Platform version** | `v4.5`                |
| **BC breaks**                  | no                                                |
| **Doc needed**                 | no                                                |

This PR allows payload to be replaced when creating `EndpointRequestDefinition`s in a data provider.

First of all, it introduces the `withPayload` method, which returns a clone of a request definition with changed payload.

Second, payload name is now always set by the factory. This prevents an issue where - since name is used as data provider dataset key - changing the request payload caused data provider to contain multiple entries under the same key, resulting in PHPUnit error.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ibexa/engineering`).
