### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.0'
+          - '8.3'
     steps:
       - uses: actions/checkout@v3
 
@@ -42,10 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
-          - '8.0'
-          - '8.1'
-          - '8.2'
+          - '8.3'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         php:
           - '8.3'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
@@ -26,7 +26,7 @@ jobs:
           extensions: 'pdo_sqlite, gd'
           tools: cs2pr
 
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           dependency-versions: highest
 
@@ -45,7 +45,7 @@ jobs:
           - '8.3'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
@@ -55,7 +55,7 @@ jobs:
           extensions: pdo_sqlite, gd
           tools: cs2pr
 
-      - uses: ramsey/composer-install@v2
+      - uses: ramsey/composer-install@v3
         with:
           dependency-versions: highest
 

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4 || ^8.0",
-        "ext-json": "*",
+        "php": ">=8.3",
         "ext-dom": "*",
+        "ext-json": "*",
         "ibexa/test-core": "~5.0.x-dev",
         "justinrainbow/json-schema": "^5.2",
         "symfony/browser-kit": "^6.4",

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         "ext-dom": "*",
         "ibexa/test-core": "~5.0.x-dev",
         "justinrainbow/json-schema": "^5.2",
-        "symfony/browser-kit": "^5.4",
-        "symfony/mime": "^5.4",
-        "symfony/proxy-manager-bridge": "^5.4",
-        "symfony/translation": "^5.4",
-        "symfony/validator": "^5.4"
+        "symfony/browser-kit": "^6.4",
+        "symfony/mime": "^6.4",
+        "symfony/proxy-manager-bridge": "^6.4",
+        "symfony/translation": "^6.4",
+        "symfony/validator": "^6.4"
     },
     "require-dev": {
         "ibexa/code-style": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/validator": "^6.4"
     },
     "require-dev": {
-        "ibexa/code-style": "^1.1",
+        "ibexa/code-style": "~2.0.0",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "phpstan/phpstan": "^1.2",

--- a/src/contracts/WebTestCase.php
+++ b/src/contracts/WebTestCase.php
@@ -70,7 +70,7 @@ abstract class WebTestCase extends SymfonyWebTestCase
         $apiUser = $userService->loadUserByLogin('admin');
         $symfonyUser = $this->createMock(UserInterface::class);
         $symfonyUser->method('getRoles')->willReturn(['ROLE_USER']);
-        $symfonyUser->method('getUsername')->willReturn('admin');
+        $symfonyUser->method('getUserIdentifier')->willReturn('admin');
 
         return new UserWrapped($symfonyUser, $apiUser);
     }

--- a/tests/lib/Request/Value/EndpointRequestDefinitionTest.php
+++ b/tests/lib/Request/Value/EndpointRequestDefinitionTest.php
@@ -18,7 +18,7 @@ use RuntimeException;
 final class EndpointRequestDefinitionTest extends TestCase
 {
     /**
-     * @return iterable<string, array{null|string, 'xml'|'json'}>
+     * @return iterable<string, array{string|null, 'xml'|'json'}>
      */
     public function getDataForTestExtractFormatFromAcceptHeader(): iterable
     {


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|


#### Related PRs:
- https://github.com/ibexa/core/pull/447
- https://github.com/ibexa/doctrine-schema/pull/27
- https://github.com/ibexa/test-core/pull/13

#### Description:

This PR bumps Symfony to v6. Upgraded also Ibexa Code Style and fixed unrelated CS issue (pops up on 1.1 as well). Switched CI to run on PHP 8.3 and use newer GHA action versions.

Key changes:

- [x] [Composer] Bumped Symfony packages requirements to ^6.4
- [x] [Composer][CS] Bumped Ibexa Code Style to ~2.0.0
- [x] [CS] Fixed outstanding CS issue in EndpointRequestDefinitionTest

#### QA:

Sanities in the form of regression tests.

#### Documentation:

No documentation required.