### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,31 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      -   uses: ramsey/composer-install@v3
+          with:
+            dependency-versions: highest
+
+      -   name: Run rector
+          run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "ibexa/code-style": "~2.0.0",
         "ibexa/core": "~5.0.x-dev",
         "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "phpstan/phpstan": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9"

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
+    ]);


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x. Added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
