### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         "ext-json": "*",
         "ibexa/test-core": "~5.0.x-dev",
         "justinrainbow/json-schema": "^5.2",
-        "symfony/browser-kit": "^7.2",
-        "symfony/mime": "^7.2",
-        "symfony/translation": "^7.2",
-        "symfony/validator": "^7.2"
+        "symfony/browser-kit": "^7.3",
+        "symfony/mime": "^7.3",
+        "symfony/translation": "^7.3",
+        "symfony/validator": "^7.3"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

